### PR TITLE
Ensure application directory exists before navigating in installer script

### DIFF
--- a/install-update-cursor.sh
+++ b/install-update-cursor.sh
@@ -64,6 +64,12 @@ echo ""
 # Start update process
 info "Starting Cursor update process..."
 
+# Create application directory if it doesn't exist
+if [ ! -d "$APP_DIR" ]; then
+    mkdir -p "$APP_DIR"
+    success "Created application directory: $APP_DIR"
+fi
+
 # Navigate to application directory
 cd "$APP_DIR" || { error "Failed to navigate to $APP_DIR"; exit 1; }
 


### PR DESCRIPTION
This PR adds a pre-navigation check in the [install-update-cursor.sh](https://github.com/MdIshtiaque/cursor-installer/blob/main/install-update-cursor.sh) script to guarantee that the `$APP_DIR` directory is created if it doesn’t already exist. Without this check, the script would fail when attempting to `cd` into a non-existent directory, causing the update process to abort prematurely.